### PR TITLE
Don't publish coffeescript source on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Coffeescript source
+src


### PR DESCRIPTION
The coffeescript source is not executable directly, so the best practice for distributing this package would be not to distribute the source via npm.

It will still be accessible on the GitHub page, but reduces the package size for anyone wanting to use your package.
